### PR TITLE
Change arguments to use path-based instead of a single title

### DIFF
--- a/src/safaribookmarks/main.py
+++ b/src/safaribookmarks/main.py
@@ -47,9 +47,15 @@ def parse_args() -> Namespace:
         description="List bookmarks and folders.",
     )
     parser_list.add_argument(
-        "target",
-        nargs="?",
-        help="The UUID or title of the bookmark or folder to show. Default shows all.",
+        "path",
+        nargs="*",
+        help="The UUID or bookmark or folder path to show. Default shows all.",
+    )
+    parser_list.add_argument(
+        "--uuid",
+        type=UUID,
+        required=False,
+        help="The UUID to show.",
     )
     parser_list.set_defaults(command="list")
     parser_add = subparsers.add_parser(
@@ -58,8 +64,9 @@ def parse_args() -> Namespace:
         description="Add a bookmark or folder.",
     )
     parser_add.add_argument(
-        "title",
-        help="The title of the bookmark or folder.",
+        "path",
+        nargs="*",
+        help="The UUID or folder path to add the new bookmark or folder to.",
     )
     parser_add.add_argument(
         "--uuid",
@@ -68,8 +75,9 @@ def parse_args() -> Namespace:
         help="The UUID to use. Default is to generate a new UUID.",
     )
     parser_add.add_argument(
-        "--to",
-        help="The target folder.",
+        "--title",
+        required=True,
+        help="The title of the bookmark or folder.",
     )
     group = parser_add.add_mutually_exclusive_group(required=True)
     group.add_argument("--url", help="The URL for the bookmark.")
@@ -87,9 +95,9 @@ def parse_args() -> Namespace:
         description="Remove a bookmark or folder.",
     )
     parser_remove.add_argument(
-        "targets",
+        "path",
         nargs="+",
-        help="The UUID or title of the bookmark or folder to remove.",
+        help="The UUID or path to the bookmark or folder to remove.",
     )
     parser_remove.set_defaults(command="remove")
     parser_move = subparsers.add_parser(
@@ -98,11 +106,12 @@ def parse_args() -> Namespace:
         description="Move a bookmark or folder.",
     )
     parser_move.add_argument(
-        "target", help="The UUID or title of the bookmark or folder to move."
+        "target", nargs="+", help="The UUID or path of the bookmark or folder to move."
     )
     parser_move.add_argument(
         "--to",
-        help="The destination folder.",
+        nargs="*",
+        help="The UUID or path to the destination folder.",
     )
     parser_move.set_defaults(command="move")
     parser_move = subparsers.add_parser(
@@ -111,8 +120,9 @@ def parse_args() -> Namespace:
         description="Edit a bookmark or folder.",
     )
     parser_move.add_argument(
-        "target",
-        help="The UUID or title of the bookmark or folder to change.",
+        "path",
+        nargs="+",
+        help="The UUID or path of the bookmark or folder to change.",
     )
     parser_move.add_argument(
         "--title",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,9 @@
-from argparse import Namespace
 from io import StringIO
 import pytest
 from pathlib import Path
 from shutil import copyfile
 from tempfile import TemporaryDirectory
-from typing import Any, Generator
+from typing import Any, Generator, List, Optional
 
 from safaribookmarks.cli import CLI
 
@@ -25,522 +24,438 @@ class TestCLI:
         return CLI(bookmarks_path, StringIO())
 
     @pytest.mark.parametrize(
-        ("command", "namespace", "error"),
+        ("command", "error"),
         [
             pytest.param(
                 "nope",
-                Namespace(json=False, format=None, target=None),
                 ValueError("Invalid command"),
                 id="non-existent-command",
             ),
             pytest.param(
                 "path",
-                Namespace(json=False, format=None, target=None),
+                ValueError("Invalid command"),
+                id="invalid-command",
+            ),
+            pytest.param(
+                "_get",
                 ValueError("Invalid command"),
                 id="invalid-command",
             ),
             pytest.param(
                 None,
-                Namespace(json=False, format=None, target=None),
                 ValueError("No command specified"),
                 id="no-command",
             ),
         ],
     )
-    def test_run(
-        self, cli: CLI, command: str, namespace: Namespace, error: BaseException
-    ):
+    def test_run(self, cli: CLI, command: str, error: BaseException):
         with pytest.raises(type(error), match=str(error)):
-            cli.run(command, **namespace.__dict__)
+            cli.run(command)
 
     @pytest.mark.parametrize(
-        ("args", "fixture_path"),
+        ("json", "format", "path", "fixture_path"),
         [
             pytest.param(
-                Namespace(json=False, format=None, target=None),
+                False,
+                None,
+                [],
                 FIXTURE_PATH.joinpath("list.txt"),
                 id="list-text",
             ),
             pytest.param(
-                Namespace(json=True, format=None, target=None),
+                True,
+                None,
+                [],
                 FIXTURE_PATH.joinpath("list.json"),
                 id="list-json",
             ),
             pytest.param(
-                Namespace(json=False, format="{id} {title} {url}", target=None),
+                False,
+                "{id} {title} {url}",
+                [],
                 FIXTURE_PATH.joinpath("list-format.txt"),
                 id="list-custom-format",
             ),
             pytest.param(
-                Namespace(json=False, format=None, target="BookmarksBar"),
+                False,
+                None,
+                ["BookmarksBar"],
                 FIXTURE_PATH.joinpath("list-target.txt"),
                 id="list-target",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="B441CA58-1880-4151-929E-743090B66587",
-                ),
+                False,
+                None,
+                ["BookmarksBar", "Safari Bookmarks CLI"],
                 FIXTURE_PATH.joinpath("list-leaf.txt"),
                 id="list-leaf",
             ),
+            pytest.param(
+                False,
+                None,
+                ["B441CA58-1880-4151-929E-743090B66587"],
+                FIXTURE_PATH.joinpath("list-leaf.txt"),
+                id="list-uuid",
+            ),
         ],
     )
-    def test_list(self, cli: CLI, args: Namespace, fixture_path: Path):
+    def test_list(
+        self,
+        cli: CLI,
+        json: bool,
+        format: str,
+        path: List[str],
+        fixture_path: Path,
+    ):
         with fixture_path.open("r") as file:
-            cli.list(**args.__dict__)
+            cli.list(json=json, format=format, path=path)
             cli.output.seek(0)
             assert file.read() == cli.output.read()
 
     @pytest.mark.parametrize(
-        ("args", "fixture_path"),
+        ("uuid", "list", "title", "url", "fixture_path"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    uuid=None,
-                    list=False,
-                    title=None,
-                    url="http://example.com",
-                ),
+                None,
+                False,
+                None,
+                "http://example.com",
                 FIXTURE_PATH.joinpath("add-fixed-uuid-no-title-leaf.txt"),
                 id="leaf-url",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    uuid="38691E76-D8F0-4946-B68D-370213EFEB9E",
-                    list=False,
-                    title=None,
-                    url="http://example.com",
-                ),
+                "38691E76-D8F0-4946-B68D-370213EFEB9E",
+                False,
+                None,
+                "http://example.com",
                 FIXTURE_PATH.joinpath("add-no-title-leaf.txt"),
                 id="leaf-uuid-url",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    uuid=None,
-                    list=False,
-                    title="Example",
-                    url="http://example.com",
-                ),
+                None,
+                False,
+                "Example",
+                "http://example.com",
                 FIXTURE_PATH.joinpath("add-fixed-uuid-leaf.txt"),
                 id="leaf-title-url",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    uuid="38691E76-D8F0-4946-B68D-370213EFEB9E",
-                    list=False,
-                    title="Example",
-                    url="http://example.com",
-                ),
+                "38691E76-D8F0-4946-B68D-370213EFEB9E",
+                False,
+                "Example",
+                "http://example.com",
                 FIXTURE_PATH.joinpath("add-leaf.txt"),
                 id="leaf-uuid-title-url",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    uuid="38691E76-D8F0-4946-B68D-370213EFEB9E",
-                    list=True,
-                    title="Example",
-                    url=None,
-                ),
+                "38691E76-D8F0-4946-B68D-370213EFEB9E",
+                True,
+                "Example",
+                None,
                 FIXTURE_PATH.joinpath("add-list.txt"),
                 id="list-uuid-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    uuid=None,
-                    list=True,
-                    title="Example",
-                    url=None,
-                ),
+                None,
+                True,
+                "Example",
+                None,
                 FIXTURE_PATH.joinpath("add-fixed-uuid-list.txt"),
                 id="list-title",
             ),
         ],
     )
     @pytest.mark.parametrize(
-        "to", [None, "3B5180DB-831D-4F1A-AE4A-6482D28D66D5", "BookmarksMenu"]
+        "path", [["3B5180DB-831D-4F1A-AE4A-6482D28D66D5"], ["BookmarksMenu"]]
     )
     def test_add__valid(
-        self, cli: CLI, args: Namespace, fixture_path: Path, to: str, monkeypatch
+        self,
+        cli: CLI,
+        uuid: Optional[str],
+        list: bool,
+        title: Optional[str],
+        url: Optional[str],
+        path: List[str],
+        fixture_path: Path,
+        monkeypatch,
     ):
         with (
             fixture_path.open("r") as file,
             monkeypatch.context() as m,
         ):
             m.setattr("uuid.uuid4", lambda: "8693E85C-83FC-4F42-AFB2-40B9CFACAAA0")
-            args.to = to
-            cli.add(**args.__dict__)
+            cli.add(uuid=uuid, list=list, title=title, url=url, path=path)
             cli.output.seek(0)
             assert file.read() == cli.output.read()
 
     @pytest.mark.parametrize(
-        ("args", "error"),
+        ("list", "uuid", "title", "url", "path", "error"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    list=True,
-                    uuid=None,
-                    title=None,
-                    url=None,
-                    to=None,
-                ),
+                True,
+                None,
+                None,
+                None,
+                [],
                 "Title is required",
                 id="missing-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    list=True,
-                    uuid=None,
-                    title="Example",
-                    url="http://example.com",
-                    to=None,
-                ),
+                True,
+                None,
+                "Example",
+                "http://example.com",
+                [],
                 "URL is not supported by lists",
                 id="with-url",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    list=False,
-                    uuid=None,
-                    title="Example",
-                    url="http://example.com",
-                    to="AB38D373-1266-495A-8CAC-422A771CF70A",
-                ),
+                False,
+                None,
+                "Example",
+                "http://example.com",
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
                 "Invalid destination",
                 id="leaf-target",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    list=False,
-                    uuid=None,
-                    title="Example",
-                    url="http://example.com",
-                    to="F1DF1813-B60B-461A-B497-51AF24AD2925",
-                ),
+                False,
+                None,
+                "Example",
+                "http://example.com",
+                ["F1DF1813-B60B-461A-B497-51AF24AD2925"],
                 "Invalid destination",
                 id="nonexistent-uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    list=False,
-                    uuid=None,
-                    title="Example",
-                    url="http://example.com",
-                    to="Unknown",
-                ),
+                False,
+                None,
+                "Example",
+                "http://example.com",
+                ["Unknown"],
                 "Invalid destination",
                 id="nonexistent-title",
             ),
         ],
     )
-    def test_add__invalid(self, cli: CLI, args: Namespace, error: str):
+    def test_add__invalid(
+        self,
+        cli: CLI,
+        list: bool,
+        uuid: Optional[str],
+        title: Optional[str],
+        url: Optional[str],
+        path: List[str],
+        error: str,
+    ):
         with pytest.raises(ValueError, match=error):
-            cli.add(**args.__dict__)
+            cli.add(list=list, uuid=uuid, title=title, url=url, path=path)
 
     @pytest.mark.parametrize(
-        ("args", "fixture_path"),
+        ("path", "fixture_path"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    targets=["B441CA58-1880-4151-929E-743090B66587"],
-                ),
+                ["B441CA58-1880-4151-929E-743090B66587"],
                 FIXTURE_PATH.joinpath("remove-leaf.txt"),
                 id="remove-leaf-by-uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    targets=["Safari Bookmarks CLI"],
-                ),
+                ["BookmarksBar", "Safari Bookmarks CLI"],
                 FIXTURE_PATH.joinpath("remove-leaf.txt"),
                 id="remove-leaf-by-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    targets=["3B5180DB-831D-4F1A-AE4A-6482D28D66D5"],
-                ),
+                ["3B5180DB-831D-4F1A-AE4A-6482D28D66D5"],
                 FIXTURE_PATH.joinpath("remove-list.txt"),
                 id="remove-list-by-uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    targets=["BookmarksBar"],
-                ),
+                ["BookmarksBar"],
                 FIXTURE_PATH.joinpath("remove-list.txt"),
                 id="remove-list-by-title",
             ),
-            pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    targets=["Python", "Safari"],
-                ),
-                FIXTURE_PATH.joinpath("remove-multiple.txt"),
-                id="remove-multiple",
-            ),
         ],
     )
-    def test_remove__valid(self, cli: CLI, args: Namespace, fixture_path: Path):
+    def test_remove__valid(self, cli: CLI, path: List[str], fixture_path: Path):
         with fixture_path.open("r") as file:
-            cli.remove(**args.__dict__)
+            cli.remove(path=path)
             cli.output.seek(0)
             assert file.read() == cli.output.read()
 
     @pytest.mark.parametrize(
-        ("args", "error"),
+        ("path", "error"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    targets=["BF7BB6D9-AF1D-4B5C-A95A-7765E9C5B199"],
-                ),
+                ["BF7BB6D9-AF1D-4B5C-A95A-7765E9C5B199"],
                 "Target not found",
                 id="uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    targets=["Unknown"],
-                ),
+                ["Unknown"],
                 "Target not found",
                 id="title",
             ),
         ],
     )
-    def test_remove__invalid(self, cli: CLI, args: Namespace, error: str):
+    def test_remove__invalid(self, cli: CLI, path: List[str], error: str):
         with pytest.raises(ValueError, match=error):
-            cli.remove(**args.__dict__)
+            cli.remove(path=path)
 
     @pytest.mark.parametrize(
-        ("args", "fixture_path"),
+        ("path", "to", "fixture_path"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="AB38D373-1266-495A-8CAC-422A771CF70A",
-                    to="20ABDC16-B491-47F4-B252-2A3065CFB895",
-                ),
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
+                ["20ABDC16-B491-47F4-B252-2A3065CFB895"],
                 FIXTURE_PATH.joinpath("move-leaf.txt"),
                 id="leaf-by-uuid",
             ),
             pytest.param(
-                Namespace(json=False, format=None, target="Safari", to="BookmarksMenu"),
+                ["BookmarksBar", "Safari"],
+                ["BookmarksMenu"],
                 FIXTURE_PATH.joinpath("move-leaf.txt"),
                 id="leaf-by-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="3B5180DB-831D-4F1A-AE4A-6482D28D66D5",
-                    to="20ABDC16-B491-47F4-B252-2A3065CFB895",
-                ),
+                ["3B5180DB-831D-4F1A-AE4A-6482D28D66D5"],
+                ["20ABDC16-B491-47F4-B252-2A3065CFB895"],
                 FIXTURE_PATH.joinpath("move-list.txt"),
                 id="list-by-uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="BookmarksBar",
-                    to="BookmarksMenu",
-                ),
+                ["BookmarksBar"],
+                ["BookmarksMenu"],
                 FIXTURE_PATH.joinpath("move-list.txt"),
                 id="list-by-title",
             ),
         ],
     )
-    def test_move__valid(self, cli: CLI, args: Namespace, fixture_path: Path):
+    def test_move__valid(
+        self, cli: CLI, path: List[str], to: List[str], fixture_path: Path
+    ):
         with fixture_path.open("r") as file:
-            cli.move(**args.__dict__)
+            cli.move(path=path, to=to)
             cli.output.seek(0)
             assert file.read() == cli.output.read()
 
     @pytest.mark.parametrize(
-        ("args", "error"),
+        ("path", "to", "error"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="BF7BB6D9-AF1D-4B5C-A95A-7765E9C5B199",
-                    to="BookmarksMenu",
-                ),
+                ["BF7BB6D9-AF1D-4B5C-A95A-7765E9C5B199"],
+                ["BookmarksMenu"],
                 "Target not found",
                 id="nonexistent-target-by-uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="Unknown",
-                    to="BookmarksMenu",
-                ),
+                ["Unknown"],
+                ["BookmarksMenu"],
                 "Target not found",
                 id="nonexistent-target-by-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="AB38D373-1266-495A-8CAC-422A771CF70A",
-                    to="41BA6DB5-4D97-4921-ADC6-4418D1824DF4",
-                ),
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
+                ["41BA6DB5-4D97-4921-ADC6-4418D1824DF4"],
                 "Invalid destination",
                 id="nonexistent-destination-by-uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="AB38D373-1266-495A-8CAC-422A771CF70A",
-                    to="Unknown",
-                ),
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
+                ["Unknown"],
                 "Invalid destination",
                 id="nonexistent-destination-by-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="AB38D373-1266-495A-8CAC-422A771CF70A",
-                    to=None,
-                ),
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
+                [],
                 "Missing destination",
                 id="missing-destination",
             ),
         ],
     )
-    def test_move__invalid(self, cli: CLI, args: Namespace, error: str):
+    def test_move__invalid(self, cli: CLI, path: List[str], to: List[str], error: str):
         with pytest.raises(ValueError, match=error):
-            cli.move(**args.__dict__)
+            cli.move(path=path, to=to)
 
     @pytest.mark.parametrize(
-        ("args", "fixture_path"),
+        ("path", "title", "url", "fixture_path"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="AB38D373-1266-495A-8CAC-422A771CF70A",
-                    title="Updated example",
-                    url=None,
-                ),
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
+                "Updated example",
+                None,
                 FIXTURE_PATH.joinpath("edit-title-leaf.txt"),
                 id="leaf-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="AB38D373-1266-495A-8CAC-422A771CF70A",
-                    title=None,
-                    url="http://example.com",
-                ),
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
+                None,
+                "http://example.com",
                 FIXTURE_PATH.joinpath("edit-url-leaf.txt"),
                 id="leaf-url",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="AB38D373-1266-495A-8CAC-422A771CF70A",
-                    title="Updated example",
-                    url="http://example.com",
-                ),
+                ["AB38D373-1266-495A-8CAC-422A771CF70A"],
+                "Updated example",
+                "http://example.com",
                 FIXTURE_PATH.joinpath("edit-title-url-leaf.txt"),
                 id="leaf-title-and-url",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="3B5180DB-831D-4F1A-AE4A-6482D28D66D5",
-                    title="Updated example",
-                    url=None,
-                ),
+                ["3B5180DB-831D-4F1A-AE4A-6482D28D66D5"],
+                "Updated example",
+                None,
                 FIXTURE_PATH.joinpath("edit-title-list.txt"),
                 id="list-title",
             ),
         ],
     )
-    def test_edit__valid(self, cli: CLI, args: Namespace, fixture_path: Path):
+    def test_edit__valid(
+        self,
+        cli: CLI,
+        path: List[str],
+        title: Optional[str],
+        url: Optional[str],
+        fixture_path: Path,
+    ):
         with fixture_path.open("r") as file:
-            cli.edit(**args.__dict__)
+            cli.edit(path=path, title=title, url=url)
             cli.output.seek(0)
             assert file.read() == cli.output.read()
 
     @pytest.mark.parametrize(
-        ("args", "error"),
+        ("path", "title", "url", "error"),
         [
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="F04ABC44-9C55-437E-A19D-B63ED24FC185",
-                    title="Example",
-                    url="http://example.com",
-                ),
+                ["F04ABC44-9C55-437E-A19D-B63ED24FC185"],
+                "Example",
+                "http://example.com",
                 "Target not found",
                 id="nonexistent-uuid",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="Unknown",
-                    title="Example",
-                    url="http://example.com",
-                ),
+                ["Unknown"],
+                "Example",
+                "http://example.com",
                 "Target not found",
                 id="nonexistent-title",
             ),
             pytest.param(
-                Namespace(
-                    json=False,
-                    format=None,
-                    target="3B5180DB-831D-4F1A-AE4A-6482D28D66D5",
-                    title=None,
-                    url="http://example.com",
-                ),
+                ["3B5180DB-831D-4F1A-AE4A-6482D28D66D5"],
+                None,
+                "http://example.com",
                 "Cannot update target url",
                 id="list-url",
             ),
         ],
     )
-    def test_edit__invalid(self, cli: CLI, args: Namespace, error: str):
+    def test_edit__invalid(
+        self,
+        cli: CLI,
+        path: List[str],
+        title: Optional[str],
+        url: Optional[str],
+        error: str,
+    ):
         with pytest.raises(ValueError, match=error):
-            cli.edit(**args.__dict__)
+            cli.edit(path=path, title=title, url=url)


### PR DESCRIPTION
**Breaking change**

Commands that accepted a bookmark title now have to specify the full hierarchical path. UUIDs can still be specified singularly.

Because of this change the remove command can only remove a single item instead of multiple.
