### PR TITLE
Refactor imports for os and plistlib to use specific symbols

### DIFF
--- a/src/safaribookmarks/cli.py
+++ b/src/safaribookmarks/cli.py
@@ -1,5 +1,5 @@
 from io import UnsupportedOperation
-import os
+from os import environ, isatty, PathLike
 from typing import IO, List, Optional
 from .safaribookmarks import SafariBookmarks, SafariBookmarkItem
 
@@ -37,7 +37,7 @@ COLORS: dict[str, int] = {
 
 
 class CLI:
-    def __init__(self, path: str, out: IO) -> None:
+    def __init__(self, path: PathLike, out: IO) -> None:
         self.bookmarks = SafariBookmarks.open(path)
         self.output = out
         self.colors = generate_colors(out)
@@ -46,7 +46,7 @@ class CLI:
     def path(self) -> str:
         return str(self.bookmarks.path)
 
-    def run(self, command: str, **kwargs) -> None:
+    def run(self, command: Optional[str], **kwargs) -> None:
         if command is None:
             raise ValueError("No command specified")
         func = getattr(self, command, None)
@@ -203,17 +203,17 @@ def generate_colors(output: IO) -> dict[str, str]:
 
 
 def supports_colors(tty: IO) -> bool:
-    if "ANSI_COLORS_DISABLED" in os.environ:
+    if "ANSI_COLORS_DISABLED" in environ:
         return False
-    if "NO_COLOR" in os.environ:
+    if "NO_COLOR" in environ:
         return False
-    if "FORCE_COLOR" in os.environ:
+    if "FORCE_COLOR" in environ:
         return True
-    if os.environ.get("TERM") == "dumb":
+    if environ.get("TERM") == "dumb":
         return False
     if not hasattr(tty, "fileno"):
         return False
     try:
-        return os.isatty(tty.fileno())
+        return isatty(tty.fileno())
     except UnsupportedOperation:
         return tty.isatty()

--- a/src/safaribookmarks/safaribookmarks.py
+++ b/src/safaribookmarks/safaribookmarks.py
@@ -1,5 +1,5 @@
-import os
-import plistlib
+from os import PathLike
+from plistlib import FMT_BINARY, FMT_XML, load as plist_load, dump as plist_dump
 from typing import IO, Iterable, Optional
 
 from .models import (
@@ -200,7 +200,7 @@ class SafariBookmarks(SafariBookmarkItem):
         return False
 
     @property
-    def path(self) -> Optional[os.PathLike]:
+    def path(self) -> Optional[PathLike]:
         return self._path
 
     @property
@@ -210,12 +210,12 @@ class SafariBookmarks(SafariBookmarkItem):
     def dump(self, fp: IO, *, binary=True) -> None:
         if hasattr(fp, "mode") and "b" not in fp.mode:
             raise IOError("Must be in binary mode")
-        fmt = plistlib.FMT_BINARY if binary else plistlib.FMT_XML
+        fmt = FMT_BINARY if binary else FMT_XML
         data = self._node.model_dump(by_alias=True)
-        plistlib.dump(data, fp, fmt=fmt, sort_keys=True, skipkeys=False)
+        plist_dump(data, fp, fmt=fmt, sort_keys=True, skipkeys=False)
 
     def save(
-        self, path: Optional[os.PathLike] = None, binary: Optional[bool] = None
+        self, path: Optional[PathLike] = None, binary: Optional[bool] = None
     ) -> None:
         if path is None:
             path = self.path
@@ -230,14 +230,14 @@ class SafariBookmarks(SafariBookmarkItem):
     def load(cls, fp: IO, *, binary=True) -> "SafariBookmarks":
         if hasattr(fp, "mode") and "b" not in fp.mode:
             raise IOError("Must be in binary mode")
-        fmt = plistlib.FMT_BINARY if binary else plistlib.FMT_XML
-        data = plistlib.load(fp, fmt=fmt)
+        fmt = FMT_BINARY if binary else FMT_XML
+        data = plist_load(fp, fmt=fmt)
         obj = cls(WebBookmarkTypeList.model_validate(data))
         obj._binary = binary
         return obj
 
     @classmethod
-    def open(cls, path: os.PathLike, binary=True) -> "SafariBookmarks":
+    def open(cls, path: PathLike, binary=True) -> "SafariBookmarks":
         with open(path, "rb") as file:
             obj = cls.load(fp=file, binary=binary)
             obj._path = path


### PR DESCRIPTION
This refactor simplifies the imports for `os` and `plistlib` by using specific symbols, improving code readability and maintainability. Type hints have been updated to use the `os.PathLike` alias directly, ensuring consistency and clarity.

- Replaced `os` and `plistlib` imports with specific symbols.
- Updated type hints to use `PathLike` instead of `os.PathLike`.
- Adjusted all references to the updated imports in the codebase.